### PR TITLE
Fix issue with falsy const values not triggering the rewrite

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ function convertExamples(schema) {
 }
 
 function rewriteConst(schema) {
-	if (schema.const) {
+	if (Object.hasOwnProperty.call(schema, 'const')) {
 		schema.enum = [ schema.const ];
 		delete schema.const;
 	}

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -19,3 +19,20 @@ it('const', async () => {
 
 	should(result).deepEqual(expected, 'converted');
 });
+
+it('falsy const', async () => {
+	const schema = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'boolean',
+		const: false
+	};
+
+	const result = await convert(schema);
+
+	const expected = {
+		type: 'boolean',
+		enum: [ false ]
+	};
+
+	should(result).deepEqual(expected, 'converted');
+});


### PR DESCRIPTION
Found a bug caused by falsy const values:

Input:
```json
{ "const": false }
```

Expected:
```json
{ "enum": [false] }
```

Actual:
```json
{ "const": false }
```