### PR TITLE
convert.sync - sync version that does not dereference

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,28 +122,17 @@ function convertTypes(schema) {
 	validateType(schema.type);
 
 	if (Array.isArray(schema.type)) {
-
-		if (schema.type.length > 2 || !schema.type.includes('null')) {
-			throw new Error('Type of ' + schema.type.join(',') + ' is too confusing for OpenAPI to understand. Found in ' + JSON.stringify(schema));
+		if (schema.type.includes('null')) {
+			schema.nullable = true;
 		}
-
-		switch (schema.type.length) {
-			case 0:
-				delete schema.type;
-				break;
-
-			case 1:
-				if (schema.type === 'null') {
-					schema.nullable = true;
-				}
-				else {
-					schema.type = schema.type[0];
-				}
-				break;
-
-			default:
-				schema.type = schema.type.find(type => type !== 'null');
-				schema.nullable = true;
+		const typesWithoutNull = schema.type.filter(type => type !== 'null');
+		if (typesWithoutNull.length === 0) {
+			delete schema.type
+		} else if (typesWithoutNull.length === 1) {
+			schema.type = typesWithoutNull[0];
+		} else {
+			delete schema.type;
+			schema.anyOf = typesWithoutNull.map(type => ({ type }));
 		}
 	}
 	else if (schema.type === 'null') {

--- a/index.js
+++ b/index.js
@@ -31,6 +31,22 @@ async function convert(schema, options = {}) {
 	return schema;
 }
 
+// we want to expose a non-async function that will skip dereferencing
+// but because the module only exposes a single function, we attach it to the main function
+// so we dont have to introduce a breaking change
+convert.sync = function convertSync(schema, options = {}) {
+	const { cloneSchema = true } = options;
+
+	if (cloneSchema) {
+		schema = JSON.parse(JSON.stringify(schema));
+	}
+
+	const vocab = schemaWalker.getVocabulary(schema, schemaWalker.vocabularies.DRAFT_04);
+	schemaWalker.schemaWalk(schema, convertSchema, null, vocab);
+	return schema;
+}
+
+
 function stripIllegalKeywords(schema) {
 	delete schema['$schema'];
 	delete schema['$id'];

--- a/test/dereference_schema.test.js
+++ b/test/dereference_schema.test.js
@@ -26,6 +26,27 @@ it('not dereferencing schema by default', async () => {
   should(result).deepEqual(expected, 'result does not match the expected');
 });
 
+it('running convert.sync is sync version equivalent to dereference: false', () => {
+  const schema = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    properties: {
+      foo: {
+        $ref: '#/definitions/foo',
+      },
+    },
+    definitions: {
+      foo: ['string', 'null'],
+    },
+  };
+
+  const result = convert.sync(JSON.parse(JSON.stringify(schema)));
+
+  const expected = { ...schema };
+  delete expected.$schema;
+
+  should(result).deepEqual(expected, 'result does not match the expected');
+});
+
 it('dereferencing schema with deference option', async () => {
   const schema = {
     $schema: 'http://json-schema.org/draft-04/schema#',

--- a/test/type-array-split.test.js
+++ b/test/type-array-split.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const convert = require('../');
+const should = require('should');
+
+it('splits type arrays correctly', async () => {
+	const schema = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'object',
+		properties: {
+			emptyArray: {
+				type: []
+			},
+			arrayWithNull: {
+				type: ['null']
+			},
+			arrayWithSingleType: {
+				type: ['string']
+			},
+			arrayWithNullAndSingleType: {
+				type: ['null', 'string'],
+			},
+			arrayWithNullAndMultipleTypes: {
+				type: ['null', 'string', 'number'],
+			},
+			arrayWithMultipleTypes: {
+				type: ['string', 'number'],
+			},
+		}
+	};
+
+	const result = await convert(schema);
+
+	const expected = {
+		type: 'object',
+		properties: {
+			emptyArray: {},
+			arrayWithNull: {
+				nullable: true,
+			},
+			arrayWithSingleType: {
+				type: 'string',
+			},
+			arrayWithNullAndSingleType: {
+				nullable: true,
+				type: 'string',
+			},
+			arrayWithNullAndMultipleTypes: {
+				nullable: true,
+				anyOf: [
+					{ type: 'string' },
+					{ type: 'number' },
+				],
+			},
+			arrayWithMultipleTypes: {
+				anyOf: [
+					{ type: 'string' },
+					{ type: 'number' },
+				],
+			},
+		}
+	};
+
+	should(result).deepEqual(expected, 'converted');
+});


### PR DESCRIPTION
This introduces a new convert.sync method which is a synchronous version equivalent to calling with dereference = false.

In my use case the function being asynchronous introduced a whole chain of async function calls which added unnecessary complexity. This will help.

Thanks!!