### PR TITLE
Throw dereferencing errors

### DIFF
--- a/test/dereference_schema.test.js
+++ b/test/dereference_schema.test.js
@@ -104,3 +104,23 @@ it('dereferencing schema with file references', async () => {
 
   should(result).deepEqual(expected, 'result does not match the expected');
 });
+
+it('throws an error when dereferecing fails', async () => {
+  const schema = {
+    $schema: "http://json-schema.org/draft-04/schema#",
+    properties: {
+      foo: {
+        $ref: "./bad.json",
+      },
+    },
+  };
+
+  let error;
+  try {
+    await convert(schema, { dereference: true });
+  } catch (e) {
+    error = e;
+  }
+
+  should(error).have.property('errors')
+})


### PR DESCRIPTION
# Motivation

I'm working on converting schemas from [backstage.io](https://backstage.io) into OpenAPI for https://github.com/backstage/backstage/issues/2566. The [schema in master](https://github.com/backstage/backstage/blob/master/packages/catalog-model/src/schema/Entity.schema.json#L53) seems to use incorrect references so I was surprised to find that json-schema-to-openapi-schema did not fail. It was quite confusing because the `$ref` didn't get resolved but the function did not fail.

Once I started looking at the code, I realized that `resolver.resolve` succeeds even if dereferencing fails. I believe `@stoplight/json-ref-resolver` should actually throw an error in this case but that would be a substantial breaking change to that library. Instead, I'm just fixing error reporting in this library.

# Approach

Throw an error when dereferencing has errors in results. I added a test for this.
