### PR TITLE
fix: change converter return type to a promise

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,5 +7,5 @@ declare namespace JsonSchemaToOpenapiSchema {
 declare function JsonSchemaToOpenapiSchema<T = Record<string | number, any>>(
   schema: Record<string | number, any>,
   options?: JsonSchemaToOpenapiSchema.Options
-): T;
+): Promise<T>;
 export = JsonSchemaToOpenapiSchema;


### PR DESCRIPTION
Changes the converter function type declaration return type to a promise to match the function: https://github.com/openapi-contrib/json-schema-to-openapi-schema/blob/master/index.js#L27