### PR TITLE
Bump json-schema-walker to 1.0.0 to support null default values

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"dependencies": {
 		"@apidevtools/json-schema-ref-parser": "^9.0.9",
-		"json-schema-walker": "^0.0.4",
+		"json-schema-walker": "^1.0.0",
 		"openapi-types": "^12.0.0",
 		"yargs": "^17.5.1"
 	},

--- a/test/default-null.test.ts
+++ b/test/default-null.test.ts
@@ -1,0 +1,28 @@
+import convert from '../src';
+
+it('supports default values of null', async ({ expect }) => {
+	const schema = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'object',
+		properties: {
+			nullableStringWithDefault: {
+				default: null,
+				oneOf: [{ type: 'string' }, { type: 'null' }],
+			}
+		}
+	};
+
+	const result = await convert(schema);
+
+	const expected = {
+		type: 'object',
+		properties: {
+			nullableStringWithDefault: {
+				default: null,
+				oneOf: [{ type: 'string' }, { nullable: true }],
+			}
+		}
+	};
+
+	expect(result).toEqual(expected);
+});


### PR DESCRIPTION
Bump `json-schema-walker` to `^1.0.0` to pull down [this PR](https://github.com/jonluca/json-schema-walker/pull/1)